### PR TITLE
Move compile to builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache git make build-base && \
 FROM alpine:latest
 COPY --from=builder /root/vlmcsd/bin/vlmcsd /vlmcsd
 
-EXPOSE 1688
+EXPOSE 1688/tcp
 
 CMD ["/vlmcsd", "-D", "-d", "-t", "3", "-e", "-v"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-FROM alpine:latest
+FROM alpine:latest as builder
+WORKDIR /root
+RUN apk add --no-cache git make build-base && \
+    git clone https://github.com/Wind4/vlmcsd.git && \
+    cd vlmcsd && \
+    make
 
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache build-base gcc abuild binutils cmake git \
-    && cd / \
-    && git clone https://github.com/Wind4/vlmcsd.git vlmgit \
-    && cd vlmgit \
-    && make \
-    && chmod +x bin/vlmcsd \
-    && mv bin/vlmcsd / \
-    && cd / \
-    && apk del build-base gcc abuild binutils cmake git \
-    && rm -rf /vlmgit  \
-    && rm -rf /var/cache/apk/*
+FROM alpine:latest
+COPY --from=builder /root/vlmcsd/bin/vlmcsd /vlmcsd
 
 EXPOSE 1688
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest as builder
 WORKDIR /root
 RUN apk add --no-cache git make build-base && \
-    git clone https://github.com/Wind4/vlmcsd.git && \
+    git clone --branch master --single-branch https://github.com/Wind4/vlmcsd.git && \
     cd vlmcsd && \
     make
 


### PR DESCRIPTION
This type of compile on-the-fly docker is suited to a multi-stage build architecture. The new image is ~5MB and only copies the compiled file it requires from the intermediary image.