### PR TITLE
add tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache git make build-base && \
 
 FROM alpine:latest
 COPY --from=builder /root/vlmcsd/bin/vlmcsd /vlmcsd
+RUN apk add --no-cache tzdata
 
 EXPOSE 1688/tcp
 


### PR DESCRIPTION
add tzdata package to allow timezone change in logs

instead of just UTC
`2020-08-07 20:54:46: vlmcsd svn1113-3-g65228e5, built 2020-08-07 20:54:03 UTC started successfully`
changed to Europe/London via TZ environment
`2020-08-07 21:54:27: vlmcsd svn1113-3-g65228e5, built 2020-08-07 20:54:03 UTC started successfully`